### PR TITLE
Add support to use JNDI service with carbon-datasources in non-OSGi environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ A custom JNDI context can be plugged in easily by adding its initial context fac
 </datasources-configuration>
 ````
 
-The carbon-datasources bundle picks these xml configuration and build the data sources. The client application could retrieve datasources using the services provided by the carbon-datasources bundle. The JNDI support to retrieve the carbon datsources in non-OSGi environment will be added soon.
+The carbon-datasources bundle picks these xml configuration and build the data sources. The client application could retrieve datasources using the services provided by the carbon-datasources bundle. The In-memory JNDI context support is available to be used with to retrieve the carbon datsources in non-OSGi environment.
 The datasources defined in configuration files are initialized by the DataSourceManager. They can be retrieved using `DataSourceService` using their names. The `DataSourceManagementService` can be used to perform managerial operations on datasources. Also a datasource can be retrieved via jndi lookup using its jndi config names.
 
 The following is a sample code which loads and initializes the datsources defined in configuration files from `configFilePath` using DataSourceManager and performs some operation using the services.

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ public class ActivatorComponent {
 ### Using carbon datasources in non-OSGi environment
 
 The datasources required for non-OSGi client application can be defined in a configuration file and naming convention of the configuration file is *-datasources.xml. Refer the sample configuration file as follows;
-JNDI configuration cannot be added to a datasource because JNDI support is not there for non-OSGi applications at the moment.
+If there is no jndi config defined explicitly in datasource definition, it will use the InMemoryInitialContextFactory to bind datasource objects to jndi context using carbon-jndi.
 
 ````xml
 <datasources-configuration>
@@ -191,8 +191,41 @@ JNDI configuration cannot be added to a datasource because JNDI support is not t
 </datasources-configuration>
 ````
 
+A custom JNDI context can be plugged in easily by adding its initial context factory class in `jndiConfig` as below using the JNDI Context.INITIAL_CONTEXT_FACTORY("java.naming.factory.initial") property.
+````
+<datasources-configuration>
+    <datasources>
+        <datasource>
+            <name>WSO2_CARBON_DB</name>
+            <description>The datasource used for registry and user manager</description>
+            <jndiConfig>
+                <name>jdbc/WSO2CarbonDB/test</name>
+                <useJndiReference>true</useJndiReference>
+                <environment>
+                    <property name="java.naming.factory.initial">org.wso2.carbon.jndi.internal.InMemoryInitialContextFactory</property>
+                </environment>
+            </jndiConfig>
+            <definition type="RDBMS">
+                <configuration>
+                    <url>jdbc:h2:./target/database/TEST_DB1;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000</url>
+                    <username>wso2carbon</username>
+                    <password>wso2carbon</password>
+                    <driverClassName>org.h2.Driver</driverClassName>
+                    <maxActive>50</maxActive>
+                    <maxWait>60000</maxWait>
+                    <testOnBorrow>true</testOnBorrow>
+                    <validationQuery>SELECT 1</validationQuery>
+                    <validationInterval>30000</validationInterval>
+                    <defaultAutoCommit>false</defaultAutoCommit>
+                </configuration>
+            </definition>
+        </datasource>
+    </datasources>
+</datasources-configuration>
+````
+
 The carbon-datasources bundle picks these xml configuration and build the data sources. The client application could retrieve datasources using the services provided by the carbon-datasources bundle. The JNDI support to retrieve the carbon datsources in non-OSGi environment will be added soon.
-The datasources defined in configuration files are initialized by the DataSourceManager. They can be retrieved using `DataSourceService` using their names. The `DataSourceManagementService` can be used to perform managerial operations on datasources.
+The datasources defined in configuration files are initialized by the DataSourceManager. They can be retrieved using `DataSourceService` using their names. The `DataSourceManagementService` can be used to perform managerial operations on datasources. Also a datasource can be retrieved via jndi lookup using its jndi config names.
 
 The following is a sample code which loads and initializes the datsources defined in configuration files from `configFilePath` using DataSourceManager and performs some operation using the services.
 
@@ -202,25 +235,33 @@ The following is a sample code which loads and initializes the datsources define
         DataSourceService dataSourceService = new DataSourceServiceImpl();
         DataSourceManagementService dataSourceMgtService = new DataSourceManagementServiceImpl();
         String analyticsDataSourceName = "WSO2_ANALYTICS_DB";
-        
+        String analyticsDataSourceJndiConfigName = "java:comp/env/jdbc/WSO2AnalyticsDB/test";
+
         try {
+            //InitialContextFactoryBuilder has to be set to NamingManager to use InitialContext API
+            NamingManager.setInitialContextFactoryBuilder(new DefaultContextFactoryBuilder());
+
             //Load and initialize the datasources defined in configuration files
             dataSourceManager.initDataSources(configFilePath.toFile().getAbsolutePath());
-            
-            //Get datsources using DataSourceManagement service
+
+            //Get datasources using DataSourceManagement service
             logger.info("Initial data source count: " + dataSourceMgtService.getDataSource().size());
-            
+
             //Get a particular datasource using its name
             logger.info("Found " + analyticsDataSourceName + ": " + (
                     dataSourceService.getDataSource(analyticsDataSourceName) != null ? true : false));
-            
+
+            //Get a datasource username using jndi lookup
+            Context context = new InitialContext();
+            logger.info(analyticsDataSourceName + " datasource username retrieved via jndi lookup: "
+                    + ((HikariDataSource) context.lookup(analyticsDataSourceJndiConfigName)).getUsername());
+
             //Delete a datasource using its name
             dataSourceMgtService.deleteDataSource(analyticsDataSourceName);
             logger.info("Deleted " + analyticsDataSourceName + " successfully");
             logger.info("Data source count after deleting " + analyticsDataSourceName + ": " + dataSourceMgtService
                     .getDataSource().size());
-
-        } catch (DataSourceException e) {
+        } catch (DataSourceException | NamingException e) {
             logger.error("Error occurred while using carbon datasource.", e);
         }
 ````

--- a/README.md
+++ b/README.md
@@ -164,7 +164,8 @@ public class ActivatorComponent {
 ### Using carbon datasources in non-OSGi environment
 
 The datasources required for non-OSGi client application can be defined in a configuration file and naming convention of the configuration file is *-datasources.xml. Refer the sample configuration file as follows;
-If there is no jndi config defined explicitly in datasource definition, it will use the InMemoryInitialContextFactory to bind datasource objects to jndi context using carbon-jndi.
+If there is no jndi config defined explicitly in datasource definition, it will use the InMemoryInitialContextFactory to bind datasource objects to jndi context using carbon-jndi. In this scenario non-OSGi application needs to
+set the carbon-jndi InitialContextFactoryBuilder `org.wso2.carbon.jndi.internal.spi.builder.DefaultContextFactoryBuilder` to NamingManager before initializing datasources.
 
 ````xml
 <datasources-configuration>
@@ -238,7 +239,9 @@ The following is a sample code which loads and initializes the datsources define
         String analyticsDataSourceJndiConfigName = "java:comp/env/jdbc/WSO2AnalyticsDB/test";
 
         try {
-            //InitialContextFactoryBuilder has to be set to NamingManager to use InitialContext API
+            //InitialContextFactoryBuilder has to be set to NamingManager to use InitialContext API if the datasource
+            // definition does not have a jndiConfig element(ie datasource is initialized by default with JNDI
+            // context using carbon-jndi SPI DefaultContextFactoryBuilder).
             NamingManager.setInitialContextFactoryBuilder(new DefaultContextFactoryBuilder());
 
             //Load and initialize the datasources defined in configuration files

--- a/components/org.wso2.carbon.datasource.core/pom.xml
+++ b/components/org.wso2.carbon.datasource.core/pom.xml
@@ -14,7 +14,8 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>carbon-datasources</artifactId>
         <groupId>org.wso2.carbon.datasources</groupId>
@@ -99,7 +100,7 @@
                             <goal>jar</goal>
                         </goals>
                         <configuration>
-                            <excludePackageNames>org.wso2.carbon.datasource.internal</excludePackageNames>
+                            <excludePackageNames>org.wso2.carbon.datasource.core.internal</excludePackageNames>
                             <additionalparam>-Xdoclint:none</additionalparam>
                             <show>public</show>
                             <nohelp>true</nohelp>
@@ -112,7 +113,8 @@
     <properties>
         <export.package>org.wso2.carbon.datasource.core.*,
             org.wso2.carbon.datasource.rdbms.*,
-            org.wso2.carbon.datasource.utils.*</export.package>
+            org.wso2.carbon.datasource.utils.*
+        </export.package>
         <import.package>javax.xml.parsers;version=0.0.0,*;resolution:=optional</import.package>
         <dynamic.import.package>*</dynamic.import.package>
         <carbon.component>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,8 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.wso2.carbon.datasources</groupId>
@@ -376,7 +377,7 @@
         <com.zaxxer.hikaricp.version>2.4.1</com.zaxxer.hikaricp.version>
         <java.version>1.8</java.version>
         <carbon.kernel.version>5.1.0-alpha2</carbon.kernel.version>
-        <carbon.jndi.version>1.0.0-alpha</carbon.jndi.version>
+        <carbon.jndi.version>1.0.2-SNAPSHOT</carbon.jndi.version>
 
         <osgi.core.api.version>6.0.0</osgi.core.api.version>
 

--- a/sample/spi-sample/README.md
+++ b/sample/spi-sample/README.md
@@ -35,7 +35,7 @@ If there is no jndi config defined explicitly in datasource definition, it will 
 ````
 
 A custom JNDI context can be plugged in easily by adding its initial context factory class in `jndiConfig` as below using the JNDI Context.INITIAL_CONTEXT_FACTORY("java.naming.factory.initial") property.
-````
+````xml
 <datasources-configuration>
     <datasources>
         <datasource>

--- a/sample/spi-sample/README.md
+++ b/sample/spi-sample/README.md
@@ -1,11 +1,13 @@
 # Carbon Datasource SPI Sample
 
-This is a sample java client application which uses WSO2 carbon-datasources services exposed through Java SPI to access them in non-OSGi environment. The JNDI support is not there for carbon datasources to be used in non-OSGi environment at the moment.
+This is a sample java client application which uses WSO2 carbon-datasources services exposed through Java SPI to access them in non-OSGi environment. The carbon datasources are supported with In-memory JNDI context service provider to be used in non-OSGi environment by default via carbon-jndi and if needed a custom JNDI context provider can be plugged in to use with carbon-datasources as explained below.
 
 ## Using carbon datasources in non-OSGi environment
 
 The datasources required for non-OSGi client application can be defined in a configuration file and naming convention of the configuration file is *-datasources.xml. Refer the sample configuration file as follows;
 JNDI configuration cannot be added to a datasource because JNDI support is not there for non-OSGi applications at the moment.
+
+If there is no jndi config defined explicitly in datasource definition, it will use the InMemoryInitialContextFactory to bind datasource objects to jndi context using carbon-jndi.
 
 ````xml
 <datasources-configuration>
@@ -16,6 +18,39 @@ JNDI configuration cannot be added to a datasource because JNDI support is not t
             <definition type="RDBMS">
                 <configuration>
                     <url>jdbc:h2:./target/database/ANALYTICS_DB1;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000</url>
+                    <username>wso2carbon</username>
+                    <password>wso2carbon</password>
+                    <driverClassName>org.h2.Driver</driverClassName>
+                    <maxActive>50</maxActive>
+                    <maxWait>60000</maxWait>
+                    <testOnBorrow>true</testOnBorrow>
+                    <validationQuery>SELECT 1</validationQuery>
+                    <validationInterval>30000</validationInterval>
+                    <defaultAutoCommit>false</defaultAutoCommit>
+                </configuration>
+            </definition>
+        </datasource>
+    </datasources>
+</datasources-configuration>
+````
+
+A custom JNDI context can be plugged in easily by adding its initial context factory class in `jndiConfig` as below using the JNDI Context.INITIAL_CONTEXT_FACTORY("java.naming.factory.initial") property.
+````
+<datasources-configuration>
+    <datasources>
+        <datasource>
+            <name>WSO2_CARBON_DB</name>
+            <description>The datasource used for registry and user manager</description>
+            <jndiConfig>
+                <name>jdbc/WSO2CarbonDB/test</name>
+                <useJndiReference>true</useJndiReference>
+                <environment>
+                    <property name="java.naming.factory.initial">org.wso2.carbon.jndi.internal.InMemoryInitialContextFactory</property>
+                </environment>
+            </jndiConfig>
+            <definition type="RDBMS">
+                <configuration>
+                    <url>jdbc:h2:./target/database/TEST_DB1;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000</url>
                     <username>wso2carbon</username>
                     <password>wso2carbon</password>
                     <driverClassName>org.h2.Driver</driverClassName>

--- a/sample/spi-sample/README.md
+++ b/sample/spi-sample/README.md
@@ -5,7 +5,6 @@ This is a sample java client application which uses WSO2 carbon-datasources serv
 ## Using carbon datasources in non-OSGi environment
 
 The datasources required for non-OSGi client application can be defined in a configuration file and naming convention of the configuration file is *-datasources.xml. Refer the sample configuration file as follows;
-JNDI configuration cannot be added to a datasource because JNDI support is not there for non-OSGi applications at the moment.
 
 If there is no jndi config defined explicitly in datasource definition, it will use the InMemoryInitialContextFactory to bind datasource objects to jndi context using carbon-jndi.
 
@@ -67,7 +66,7 @@ A custom JNDI context can be plugged in easily by adding its initial context fac
 </datasources-configuration>
 ````
 
-The carbon-datasources bundle picks these xml configuration and build the data sources. The client application could retrieve datasources using the services provided by the carbon-datasources bundle. The JNDI support to retrieve the carbon datsources in non-OSGi environment will be added soon.
+The carbon-datasources bundle picks these xml configuration and build the data sources. The client application could retrieve datasources using the services provided by the carbon-datasources bundle. The In-memory JNDI context support is there to be used with the carbon datsources in non-OSGi environment.
 The datasources defined in configuration files are initialized by the `DataSourceManager`. They can be retrieved using `DataSourceService` using their names. The `DataSourceManagementService` can be used to perform managerial operations on datasources.
 
 ## Instructions to build and execute the application

--- a/sample/spi-sample/src/main/java/org/wso2/carbon/datasource/sample/DataSourceClient.java
+++ b/sample/spi-sample/src/main/java/org/wso2/carbon/datasource/sample/DataSourceClient.java
@@ -48,7 +48,9 @@ public class DataSourceClient {
         String analyticsDataSourceJndiConfigName = "java:comp/env/jdbc/WSO2AnalyticsDB/test";
 
         try {
-            //InitialContextFactoryBuilder has to be set to NamingManager to use InitialContext API
+            //InitialContextFactoryBuilder has to be set to NamingManager to use InitialContext API if the datasource
+            // definition does not have a jndiConfig element(ie datasource is initialized by default with JNDI
+            // context using carbon-jndi SPI DefaultContextFactoryBuilder).
             NamingManager.setInitialContextFactoryBuilder(new DefaultContextFactoryBuilder());
 
             //Load and initialize the datasources defined in configuration files

--- a/sample/spi-sample/src/main/java/org/wso2/carbon/datasource/sample/DataSourceClient.java
+++ b/sample/spi-sample/src/main/java/org/wso2/carbon/datasource/sample/DataSourceClient.java
@@ -15,6 +15,7 @@
  */
 package org.wso2.carbon.datasource.sample;
 
+import com.zaxxer.hikari.HikariDataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.datasource.core.DataSourceManager;
@@ -23,9 +24,14 @@ import org.wso2.carbon.datasource.core.api.DataSourceService;
 import org.wso2.carbon.datasource.core.exception.DataSourceException;
 import org.wso2.carbon.datasource.core.impl.DataSourceManagementServiceImpl;
 import org.wso2.carbon.datasource.core.impl.DataSourceServiceImpl;
+import org.wso2.carbon.jndi.internal.spi.builder.DefaultContextFactoryBuilder;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.naming.spi.NamingManager;
 
 /**
  * This is a sample SPI client which uses the carbon datasources service in non-OSGi environment.
@@ -39,25 +45,33 @@ public class DataSourceClient {
         DataSourceService dataSourceService = new DataSourceServiceImpl();
         DataSourceManagementService dataSourceMgtService = new DataSourceManagementServiceImpl();
         String analyticsDataSourceName = "WSO2_ANALYTICS_DB";
+        String analyticsDataSourceJndiConfigName = "java:comp/env/jdbc/WSO2AnalyticsDB/test";
 
         try {
+            //InitialContextFactoryBuilder has to be set to NamingManager to use InitialContext API
+            NamingManager.setInitialContextFactoryBuilder(new DefaultContextFactoryBuilder());
+
             //Load and initialize the datasources defined in configuration files
             dataSourceManager.initDataSources(configFilePath.toFile().getAbsolutePath());
 
-            //Get datsources using DataSourceManagement service
+            //Get datasources using DataSourceManagement service
             logger.info("Initial data source count: " + dataSourceMgtService.getDataSource().size());
 
             //Get a particular datasource using its name
             logger.info("Found " + analyticsDataSourceName + ": " + (
                     dataSourceService.getDataSource(analyticsDataSourceName) != null ? true : false));
 
+            //Get a datasource username using jndi lookup
+            Context context = new InitialContext();
+            logger.info(analyticsDataSourceName + " datasource username retrieved via jndi lookup: "
+                    + ((HikariDataSource) context.lookup(analyticsDataSourceJndiConfigName)).getUsername());
+
             //Delete a datasource using its name
             dataSourceMgtService.deleteDataSource(analyticsDataSourceName);
             logger.info("Deleted " + analyticsDataSourceName + " successfully");
             logger.info("Data source count after deleting " + analyticsDataSourceName + ": " + dataSourceMgtService
                     .getDataSource().size());
-
-        } catch (DataSourceException e) {
+        } catch (DataSourceException | NamingException e) {
             logger.error("Error occurred while using carbon datasource.", e);
         }
     }

--- a/sample/spi-sample/src/main/resources/conf/datasources/analytics-datasources.xml
+++ b/sample/spi-sample/src/main/resources/conf/datasources/analytics-datasources.xml
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,6 +18,10 @@ limitations under the License.
         <datasource>
             <name>WSO2_ANALYTICS_DB</name>
             <description>The datasource used for registry and user manager</description>
+            <jndiConfig>
+                <name>jdbc/WSO2AnalyticsDB/test</name>
+                <useJndiReference>true</useJndiReference>
+            </jndiConfig>
             <definition type="RDBMS">
                 <configuration>
                     <url>jdbc:h2:./target/database/ANALYTICS_DB1;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000</url>

--- a/sample/spi-sample/src/main/resources/conf/datasources/master-datasources.xml
+++ b/sample/spi-sample/src/main/resources/conf/datasources/master-datasources.xml
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,6 +18,13 @@ limitations under the License.
         <datasource>
             <name>WSO2_CARBON_DB</name>
             <description>The datasource used for registry and user manager</description>
+            <jndiConfig>
+                <name>jdbc/WSO2CarbonDB/test</name>
+                <useJndiReference>true</useJndiReference>
+                <environment>
+                    <property name="java.naming.factory.initial">org.wso2.carbon.jndi.internal.InMemoryInitialContextFactory</property>
+                </environment>
+            </jndiConfig>
             <definition type="RDBMS">
                 <configuration>
                     <url>jdbc:h2:./target/database/TEST_DB1;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000</url>

--- a/sample/spi-sample/src/main/resources/log4j.properties
+++ b/sample/spi-sample/src/main/resources/log4j.properties
@@ -12,8 +12,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-# Set root logger level to DEBUG and its only appender to A1.
-log4j.rootLogger=DEBUG, A1
+# Set root logger level to INFO and its only appender to A1.
+log4j.rootLogger=INFO, A1
 
 # A1 is set to be a ConsoleAppender.
 log4j.appender.A1=org.apache.log4j.ConsoleAppender

--- a/tests/coverage-report/pom.xml
+++ b/tests/coverage-report/pom.xml
@@ -19,13 +19,12 @@
     <parent>
         <artifactId>carbon-datasources</artifactId>
         <groupId>org.wso2.carbon.datasources</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>carbon-datasources-coverage-reports</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
     <name>WSO2 Carbon Datasources - Coverage Reports</name>
     <description>Coverage Report for Carbon Datasources by merging unit and OSGi tests</description>
     <url>http://wso2.com</url>

--- a/tests/coverage-report/pom.xml
+++ b/tests/coverage-report/pom.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>carbon-datasources</artifactId>
+        <groupId>org.wso2.carbon.datasources</groupId>
+        <version>1.1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>carbon-datasources-coverage-reports</artifactId>
+    <version>1.0.2-SNAPSHOT</version>
+    <name>WSO2 Carbon Datasources - Coverage Reports</name>
+    <description>Coverage Report for Carbon Datasources by merging unit and OSGi tests</description>
+    <url>http://wso2.com</url>
+
+    <profiles>
+        <profile>
+            <id>with-tests</id>
+            <activation>
+                <property>
+                    <name>!maven.test.skip</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+
+                            <execution>
+                                <id>copy-jacoco-dependencies</id>
+                                <phase>compile</phase>
+                                <goals>
+                                    <goal>copy-dependencies</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>${project.build.directory}</outputDirectory>
+                                    <includeTypes>jar</includeTypes>
+                                    <includeArtifactIds>org.jacoco.ant</includeArtifactIds>
+                                    <stripVersion>true</stripVersion>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <!-- Ant plugin - Merge Jacoco Reports -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target xmlns:jacoco="antlib:org.jacoco.ant">
+                                        <taskdef uri="antlib:org.jacoco.ant" resource="org/jacoco/ant/antlib.xml">
+                                            <classpath path="${project.build.directory}"/>
+                                        </taskdef>
+                                        <jacoco:report>
+                                            <executiondata>
+                                                <fileset dir="../../components/org.wso2.carbon.datasource.core/target">
+                                                    <include name="jacoco.exec"/>
+                                                </fileset>
+                                                <fileset dir="../osgi-tests/target">
+                                                    <include name="jacoco.exec"/>
+                                                </fileset>
+                                            </executiondata>
+
+                                            <structure name="Carbon JNDI - Coverage Report">
+                                                <classfiles>
+                                                    <fileset
+                                                            dir="../../components/org.wso2.carbon.datasource.core/target/classes"/>
+                                                </classfiles>
+                                                <sourcefiles encoding="UTF-8">
+                                                    <fileset
+                                                            dir="../../components/org.wso2.carbon.datasource.core/src"/>
+                                                </sourcefiles>
+                                            </structure>
+                                            <html destdir="${project.build.directory}/site/jacoco"/>
+                                        </jacoco:report>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.jacoco</groupId>
+                                <artifactId>org.jacoco.ant</artifactId>
+                                <version>${org.jacoco.ant.version}</version>
+                            </dependency>
+                        </dependencies>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/tests/osgi-tests/src/test/resources/testng.xml
+++ b/tests/osgi-tests/src/test/resources/testng.xml
@@ -17,8 +17,8 @@
 
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
 
-<suite name="Carbon-JNDI-Test-Suite">
-    <test name="carbon-jndi-tests" preserve-order="true" parallel="false">
+<suite name="Carbon-DataSource-OSGi-Test-Suite">
+    <test name="carbon-datasource-OSGi-tests" preserve-order="true" parallel="false">
         <classes>
             <!--<class name="org.wso2.carbon.datasource.osgi.DataSourceServiceTest"/>-->
             <class name="org.wso2.carbon.datasource.osgi.DataSourceManagementServiceTest"/>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -14,7 +14,8 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>carbon-datasources</artifactId>
         <groupId>org.wso2.carbon.datasources</groupId>
@@ -27,5 +28,6 @@
     <name>WSO2 Carbon Datasources - Tests Parent</name>
     <modules>
         <module>osgi-tests</module>
+        <module>coverage-report</module>
     </modules>
 </project>


### PR DESCRIPTION
The JNDI service can be used with carbon-datasources in non-OSGi environment with the new changes introduced in carbon-jndi[[1]](https://github.com/wso2/carbon-jndi/pull/30).

If there is no jndi config defined explicitly in datasource definition, it will use the InMemoryInitialContextFactory to bind datasource objects to jndi context using carbon-jndi. A custom JNDI context can be plugged in easily by adding its initial context factory class in `jndiConfig` using the JNDI Context.INITIAL_CONTEXT_FACTORY("java.naming.factory.initial") property.