### PR TITLE
Add functionality to turn on/off JNDI binding.

### DIFF
--- a/components/org.wso2.carbon.datasource.core/src/main/java/org/wso2/carbon/datasource/core/DataSourceJndiManager.java
+++ b/components/org.wso2.carbon.datasource.core/src/main/java/org/wso2/carbon/datasource/core/DataSourceJndiManager.java
@@ -35,6 +35,8 @@ public class DataSourceJndiManager {
 
     private static final String JAVA_COMP_CONTEXT_STRING = "java:comp";
     private static final String ENV_CONTEXT_STRING = "env";
+    private static final String JNDI_BIND_OFF = "jndi.bind.off";
+
     private static Logger logger = LoggerFactory.getLogger(DataSourceJndiManager.class);
 
     /**
@@ -59,9 +61,15 @@ public class DataSourceJndiManager {
      */
     public static void register(DataSourceMetadata dataSourceMetadata, Object dataSourceObject,
             DataSourceReader dataSourceReader) throws DataSourceException, NamingException {
+
         JNDIConfig jndiConfig = dataSourceMetadata.getJndiConfig();
-        //If JNDI configuration is not present, the data source will not be bound to a JNDI context.
-        if (jndiConfig == null) {
+
+        // We disable JNDI bind in SPI scenarios where JNDI tag is present in the datasource.xml
+        boolean isJNDIBindOff = Boolean.parseBoolean(System.getProperty(JNDI_BIND_OFF));
+
+        // If JNDI configuration is not present or we disabled the JNDI bind using system property, the data source will
+        // not be bound to a JNDI context.
+        if (jndiConfig == null || isJNDIBindOff) {
             if (logger.isDebugEnabled()) {
                 logger.debug("JNDI info not found for " + dataSourceMetadata.getName());
             }


### PR DESCRIPTION
## Purpose
Add the functionality to turn on/off JNDI binding using a system property.
Git issue: https://github.com/wso2/carbon-datasources/issues/39

## Goals
This will add the facility to read the system property "jndi.bind.off" (Boolean) and turn on/off JNDI binding. This is useful when running this in SPI mode and <jndiConfig> element present in the datasources.xml.

## Approach
N/A

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests 
   Present
 - Integration tests
   N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A
 
## Learning
N/A