### PR TITLE
Update pom version to 1.0.1-SNAPSHOT it 1.0.x branch.

### DIFF
--- a/components/org.wso2.carbon.datasource.core/pom.xml
+++ b/components/org.wso2.carbon.datasource.core/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>carbon-datasources</artifactId>
         <groupId>org.wso2.carbon.datasources</groupId>
-        <version>1.0.0</version>
+        <version>1.0.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>carbon-datasources</artifactId>
         <groupId>org.wso2.carbon.datasources</groupId>
-        <version>1.0.0</version>
+        <version>1.0.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/feature/pom.xml
+++ b/feature/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>carbon-datasources</artifactId>
         <groupId>org.wso2.carbon.datasources</groupId>
-        <version>1.0.0</version>
+        <version>1.0.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <groupId>org.wso2.carbon.datasources</groupId>
     <artifactId>carbon-datasources</artifactId>
     <packaging>pom</packaging>
-    <version>1.0.0</version>
+    <version>1.0.1-SNAPSHOT</version>
 
     <parent>
         <groupId>org.wso2</groupId>

--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>carbon-datasources</artifactId>
         <groupId>org.wso2.carbon.datasources</groupId>
-        <version>1.0.0</version>
+        <version>1.0.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>bundle</packaging>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.wso2.carbon.datasources</groupId>
             <artifactId>org.wso2.carbon.datasource.core</artifactId>
-            <version>1.0.0</version>
+            <version>1.0.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.jndi</groupId>

--- a/tests/osgi-tests/pom.xml
+++ b/tests/osgi-tests/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>carbon-datasource-tests</artifactId>
         <groupId>org.wso2.carbon.datasources</groupId>
-        <version>1.0.0</version>
+        <version>1.0.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>carbon-datasources</artifactId>
         <groupId>org.wso2.carbon.datasources</groupId>
-        <version>1.0.0</version>
+        <version>1.0.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
## Purpose
Since we are staring this branch from tag v1.0.0, we need to change the
pom version to 1.0.1-SNAPSHOT

Fixes: https://github.com/wso2/carbon-datasources/issues/41

## Goals
N/A

## Approach
N/A

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A
## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
N/A

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A
 
## Learning
N/A