### PR TITLE
datasource-core: fix improper restriction of XXE

### DIFF
--- a/components/org.wso2.carbon.datasource.core/src/main/java/org/wso2/carbon/datasource/utils/DataSourceUtils.java
+++ b/components/org.wso2.carbon.datasource.core/src/main/java/org/wso2/carbon/datasource/utils/DataSourceUtils.java
@@ -48,8 +48,10 @@ import javax.xml.bind.JAXBException;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Result;
 import javax.xml.transform.Source;
+import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
@@ -192,7 +194,11 @@ public class DataSourceUtils {
             ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
             Source xmlSource = new DOMSource(doc);
             Result result = new StreamResult(outputStream);
-            TransformerFactory.newInstance().newTransformer().transform(xmlSource, result);
+            TransformerFactory transformerFactory = TransformerFactory.newInstance();
+            transformerFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            Transformer transformer = transformerFactory.newTransformer();
+            transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+            transformer.transform(xmlSource, result);
             in = new ByteArrayInputStream(outputStream.toByteArray());
         } catch (TransformerException e) {
             throw new DataSourceException("Error in transforming DOM to InputStream", e);


### PR DESCRIPTION
## Purpose
> Implement secure use of TransformerFactory in compliance with [OWASP Guidelines](https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.md#transformerfactory) and [Sonar rules](https://rules.sonarsource.com/java/RSPEC-4435) to fix improper restriction of External XML Entity (XXE) Reference.