### PR TITLE
 Change config namespace as dataSources

### DIFF
--- a/components/org.wso2.carbon.datasource.core/src/main/java/org/wso2/carbon/datasource/core/DataSourceManager.java
+++ b/components/org.wso2.carbon.datasource.core/src/main/java/org/wso2/carbon/datasource/core/DataSourceManager.java
@@ -41,6 +41,7 @@ public class DataSourceManager {
     private static Logger logger = LoggerFactory.getLogger(DataSourceManager.class);
     private static DataSourceManager instance = new DataSourceManager();
     private static final String WSO2_DATASOURCES_NAMESPACE = "wso2.datasources";
+    private static final String DATASOURCES_NAMESPACE = "dataSources";
     private DataSourceRepository dataSourceRepository;
     private Map<String, DataSourceReader> dataSourceReaders;
     private boolean initialized = false;
@@ -131,7 +132,16 @@ public class DataSourceManager {
         try {
             // check whether datasource is configured in deployment.yaml. create datasource only if configuration
             // exists in deployment.yaml
-            if (configProvider.getConfigurationObject(WSO2_DATASOURCES_NAMESPACE) != null) {
+            if (configProvider.getConfigurationObject(DATASOURCES_NAMESPACE) != null) {
+                ArrayList<DataSourceMetadata> dataSourceList = configProvider
+                        .getConfigurationObjectList(DATASOURCES_NAMESPACE, DataSourceMetadata.class);
+                if (dataSourceList.isEmpty()) {
+                    throw new DataSourceException("Configuration 'dataSources' doesn't specify any datasource " +
+                            "configurations");
+                }
+                dataSourceConfiguration = new DataSourcesConfiguration();
+                dataSourceConfiguration.setDataSources(dataSourceList);
+            } else if (configProvider.getConfigurationObject(WSO2_DATASOURCES_NAMESPACE) != null) {
                 dataSourceConfiguration = configProvider.getConfigurationObject(DataSourcesConfiguration.class);
                 if (dataSourceConfiguration.getDataSources() == null && dataSourceConfiguration.getDataSources()
                     .isEmpty()) {

--- a/components/org.wso2.carbon.datasource.core/src/test/java/org/wso2/carbon/datasource/api/StreamlinedConfigTest.java
+++ b/components/org.wso2.carbon.datasource.core/src/test/java/org/wso2/carbon/datasource/api/StreamlinedConfigTest.java
@@ -1,0 +1,96 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.wso2.carbon.datasource.api;
+
+import org.easymock.EasyMock;
+import org.testng.Assert;
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.Test;
+import org.wso2.carbon.config.ConfigProviderFactory;
+import org.wso2.carbon.config.ConfigurationException;
+import org.wso2.carbon.config.provider.ConfigProvider;
+import org.wso2.carbon.datasource.core.DataSourceManager;
+import org.wso2.carbon.datasource.core.Utils;
+import org.wso2.carbon.datasource.core.api.DataSourceManagementService;
+import org.wso2.carbon.datasource.core.beans.DataSourceMetadata;
+import org.wso2.carbon.datasource.core.exception.DataSourceException;
+import org.wso2.carbon.datasource.core.impl.DataSourceManagementServiceImpl;
+import org.wso2.carbon.secvault.SecureVault;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+/**
+ * Test class for {@code DataSourceManagementService}.
+ */
+public class StreamlinedConfigTest {
+
+    public SecureVault secureVault;
+    protected DataSourceManager dataSourceManager;
+    private DataSourceManagementService dataSourceMgtService;
+    private static final String DATASOURCE_NAME = "WSO2_CARBON_DB_2";
+    private String[] configurationFiles = {"deployment.yaml", "wso2.datasource.yaml"};
+
+    @BeforeSuite
+    public void initialize() throws DataSourceException, ConfigurationException {
+        setEnv();
+        secureVault = EasyMock.mock(SecureVault.class);
+        ConfigProvider configProvider = ConfigProviderFactory.getConfigProvider(Paths.get(System.getProperty("carbon" +
+                ".home2"), "conf", "deployment.yaml"), secureVault);
+        dataSourceManager = DataSourceManager.getInstance();
+        dataSourceManager.initDataSources(configProvider);
+        dataSourceMgtService = new DataSourceManagementServiceImpl();
+    }
+
+    @Test
+    public void getDataSourceTest() throws DataSourceException {
+        DataSourceMetadata dataSourceMetadata = dataSourceMgtService.getDataSource(DATASOURCE_NAME);
+        Assert.assertNotNull(dataSourceMetadata, "metadata for \"" + DATASOURCE_NAME + "\" should not be null");
+    }
+
+    @Test(dependsOnMethods = "getDataSourceTest")
+    public void getDataSourceListTest() throws DataSourceException {
+        List<DataSourceMetadata> dataSourceMetadata = dataSourceMgtService.getDataSource();
+        Assert.assertEquals(1, dataSourceMetadata.size(), "Only one " + DATASOURCE_NAME + " exist in the repository.");
+    }
+
+    @Test(dependsOnMethods = "getDataSourceListTest")
+    public void addAndDeleteDataSourceTest() throws DataSourceException {
+        DataSourceMetadata dataSourceMetadata = dataSourceMgtService.getDataSource(DATASOURCE_NAME);
+        Assert.assertNotNull(dataSourceMetadata, "dataSourceMetadata should not be null");
+        dataSourceMgtService.deleteDataSource(DATASOURCE_NAME);
+        DataSourceMetadata dataSourceMetadata2 = dataSourceMgtService.getDataSource(DATASOURCE_NAME);
+        Assert.assertNull(dataSourceMetadata2, "After deleting, " + DATASOURCE_NAME + " should not exist in the "
+                + "repository");
+        dataSourceMgtService.addDataSource(dataSourceMetadata);
+        Assert.assertNotNull(dataSourceMgtService.getDataSource(DATASOURCE_NAME), DATASOURCE_NAME + " should exist in"
+                + " the repository");
+    }
+
+    private void setEnv() {
+        Path carbonHomePath = Paths.get("target", "carbonHome2");
+        System.setProperty("carbon.home2", carbonHomePath.toFile().getAbsolutePath());
+
+        for (String file : configurationFiles) {
+            Path configFilePath = Paths.get("src", "test", "resources", "confnew", file);
+            Path configPathCopyLocation = Paths.get("target", "carbonHome2", "conf",
+                    file);
+            Utils.copy(configFilePath.toFile().getAbsolutePath(), configPathCopyLocation.toFile().getAbsolutePath());
+        }
+    }
+
+}

--- a/components/org.wso2.carbon.datasource.core/src/test/resources/confnew/deployment.yaml
+++ b/components/org.wso2.carbon.datasource.core/src/test/resources/confnew/deployment.yaml
@@ -1,0 +1,86 @@
+################################################################################
+#   Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved
+#
+#   Licensed under the Apache License, Version 2.0 (the \"License\");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an \"AS IS\" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+################################################################################
+
+  # Data Sources Configuration
+dataSources:
+  - name: WSO2_CARBON_DB
+    description: The datasource used for registry and user manager
+      # JNDI mapping of a data source
+    jndiConfig:
+        # JNDI name
+        # THIS IS A MANDATORY FIELD
+      name: jdbc/WSO2CarbonDB/test
+        # JNDI Reference Flag
+      useJndiReference: true
+      # data source definition
+      environment:
+        - name: 'java.naming.factory.initial'
+          value: 'org.wso2.carbon.datasource.core.jndi.CustomContextFactory'
+      # data source definition
+    definition:
+        # data source type
+        # THIS IS A MANDATORY FIELD
+      type: RDBMS
+        # data source configuration
+      configuration:
+        jdbcUrl: 'jdbc:h2:./target/database/TEST_DB1;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000'
+        username: wso2carbon
+        password: wso2carbon
+        driverClassName: org.h2.Driver
+        maxPoolSize: 50
+        idleTimeout: 60000
+        connectionTestQuery: SELECT 1
+        validationTimeout: 30000
+        isAutoCommit: false
+  - name: WSO2_CARBON_DB_2
+    description: The datasource used for registry and user manager
+      # JNDI mapping of a data source
+    jndiConfig:
+        # JNDI name
+        # THIS IS A MANDATORY FIELD
+      name: jdbc/WSO2CarbonDB/testDb2
+        # JNDI Reference Flag
+      useJndiReference: true
+      # data source definition
+      environment:
+        - name: 'java.naming.factory.initial'
+          value: 'org.wso2.carbon.datasource.core.jndi.CustomContextFactory'
+    definition:
+        # data source type
+        # THIS IS A MANDATORY FIELD
+      type: RDBMS
+        # data source configuration
+      configuration:
+        jdbcUrl: 'jdbc:h2:./target/database/TEST_DB2;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000'
+        username: wso2carbon
+        password: wso2carbon
+        driverClassName: org.h2.Driver
+        maxPoolSize: 50
+        idleTimeout: 600
+        connectionTestQuery: SELECT 1
+        validationTimeout: 300
+        connectionTimeout: 300
+        maxLifetime: 1800
+        isAutoCommit: true
+        isReadOnly: true
+        dataSourceProperties:
+          - name: property_name_1
+            value: property_value_1
+          - name: property_name_2
+            value: property_value_2
+        invalid: invaild entry
+
+

--- a/components/org.wso2.carbon.datasource.core/src/test/resources/confnew/wso2.datasource.yaml
+++ b/components/org.wso2.carbon.datasource.core/src/test/resources/confnew/wso2.datasource.yaml
@@ -1,0 +1,47 @@
+################################################################################
+#   Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved
+#
+#   Licensed under the Apache License, Version 2.0 (the \"License\");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an \"AS IS\" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+################################################################################
+
+# datasources
+dataSources:
+  - name: WSO2_CARBON_DB
+    description: The datasource used for registry and user manager
+      # JNDI mapping of a data source
+    jndiConfig:
+        # JNDI name
+        # THIS IS A MANDATORY FIELD
+      name: jdbc/WSO2CarbonDB/test
+        # JNDI Reference Flag
+      useJndiReference: true
+      # data source definition
+      environment:
+        - name: 'java.naming.factory.initial'
+          value: 'org.wso2.carbon.datasource.core.jndi.CustomContextFactory'
+      # data source definition
+    definition:
+        # data source type
+        # THIS IS A MANDATORY FIELD
+      type: RDBMS
+        # data source configuration
+      configuration:
+        jdbcUrl: 'jdbc:h2:./target/database/TEST_DB1;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000'
+        username: wso2carbon
+        password: wso2carbon
+        driverClassName: org.h2.Driver
+        maxPoolSize: 50
+        idleTimeout: 60000
+        connectionTestQuery: SELECT 1
+        validationTimeout: 30000
+        isAutoCommit: false

--- a/components/org.wso2.carbon.datasource.core/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.datasource.core/src/test/resources/testng.xml
@@ -24,6 +24,7 @@ limitations under the License.
             <class name="org.wso2.carbon.datasource.core.DataSourceRepositoryTest" />
             <class name="org.wso2.carbon.datasource.api.DataSourceServiceTest" />
             <class name="org.wso2.carbon.datasource.api.DataSourceManagementServiceTest" />
+            <class name="org.wso2.carbon.datasource.api.StreamlinedConfigTest" />
         </classes>
     </test>
 </suite>

--- a/pom.xml
+++ b/pom.xml
@@ -434,12 +434,12 @@
         <carbon.kernel.import.version.range>[5.0.0, 6.0.0)</carbon.kernel.import.version.range>
         <carbon.jndi.version>1.0.3</carbon.jndi.version>
 
-        <carbon.config.version>2.1.2</carbon.config.version>
+        <carbon.config.version>2.1.14</carbon.config.version>
         <carbon.config.package.import.version.range>[2.0.0, 3.0.0)</carbon.config.package.import.version.range>
         <carbon.utils.version>2.0.2</carbon.utils.version>
         <carbon.utils.package.import.version.range>[2.0.0, 3.0.0)</carbon.utils.package.import.version.range>
         <carbon.touchpoint.version>1.1.0</carbon.touchpoint.version>
-        <carbon.securevault.version>5.0.8</carbon.securevault.version>
+        <carbon.securevault.version>5.0.14</carbon.securevault.version>
         <carbon.securevault.version.range>[5.0.0, 6.0.0)</carbon.securevault.version.range>
 
         <osgi.core.api.version>6.0.0</osgi.core.api.version>


### PR DESCRIPTION
## Purpose
$subject
```
# Datasource Configurations
dataSources:
  - name: WSO2_PERMISSIONS_DB
    description: The datasource used for permission feature
    jndiConfig:
      name: jdbc/PERMISSION_DB
      useJndiReference: true
    definition:
      type: RDBMS
      configuration:
        jdbcUrl: 'jdbc:h2:${sys:carbon.home}/wso2/${sys:wso2.runtime}/database/PERMISSION_DB;IFEXISTS=TRUE;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000;MVCC=TRUE'
        username: wso2carbon
        password: wso2carbon
        driverClassName: org.h2.Driver
        maxPoolSize: 10
        idleTimeout: 60000
        connectionTestQuery: SELECT 1
        validationTimeout: 30000
        isAutoCommit: false

```

## Goals
Streamline config as discussed in https://groups.google.com/forum/?hl=en#!topic/siddhi-dev/j3W4mA8jjQ8 part of the task list in https://github.com/siddhi-io/distribution/issues/263

## Approach
As in 48d9e51

## Documentation
N/A as it is backward compatible

## Automation tests
 - Unit tests - Attached herewith
 - Integration tests - N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
