### PR TITLE
Set the default minimumIdle parameter in database connection configuration.

### DIFF
--- a/components/org.wso2.carbon.datasource.core/src/main/java/org/wso2/carbon/datasource/rdbms/hikari/utils/HikariDataSourceUtils.java
+++ b/components/org.wso2.carbon.datasource.core/src/main/java/org/wso2/carbon/datasource/rdbms/hikari/utils/HikariDataSourceUtils.java
@@ -53,7 +53,7 @@ public class HikariDataSourceUtils {
             hikariConfig.setIdleTimeout(HikariConstants.IDLE_TIME_OUT);
             hikariConfig.setMaxLifetime(HikariConstants.MAX_LIFE_TIME);
             hikariConfig.setMinimumIdle(HikariConstants.MINIMUM_IDLE_SIZE);
-            hikariConfig.setMinimumIdle(HikariConstants.MAXIMUM_POOL_SIZE);
+            hikariConfig.setMaximumPoolSize(HikariConstants.MAXIMUM_POOL_SIZE);
             hikariConfig.setAutoCommit(HikariConstants.AUTO_COMMIT);
 
             Map<String, ? extends Object> configMap = (Map<String, ? extends Object>) configuration;


### PR DESCRIPTION
This will fix the mixed up scenario in the default parameter passing to the Hikari via the code base. 