### PR TITLE
Add HTTPS repo, in order to stabilize the build

### DIFF
--- a/tests/osgi-tests/pom.xml
+++ b/tests/osgi-tests/pom.xml
@@ -244,6 +244,7 @@
                                 <org.ops4j.pax.logging.DefaultServiceLog.level>DEBUG</org.ops4j.pax.logging.DefaultServiceLog.level>
                                 <org.ops4j.pax.url.mvn.localRepository>${settings.localRepository}
                                 </org.ops4j.pax.url.mvn.localRepository>
+                                <org.ops4j.pax.url.mvn.repositories>https://repo1.maven.org/maven2/</org.ops4j.pax.url.mvn.repositories>
                                 <jacoco-agent.destfile>${project.build.directory}/jacoco.exec</jacoco-agent.destfile>
                             </systemPropertyVariables>
                             <suiteXmlFiles>


### PR DESCRIPTION
Pax testing is trying to download artifact com.h2database:h2:jar:1.4.195 via the HTTP URL but the Central Repository no longer supports communication over plain HTTP. As such the OSGI test failed. This PR fixes the said issue.