### PR TITLE
Dependancy version update of commons-io

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -396,6 +396,11 @@
                     <artifactId>carbon-feature-plugin</artifactId>
                     <version>${carbon.feature.plugin.version}</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>findbugs-maven-plugin</artifactId>
+                    <version>3.0.4</version>
+                </plugin>
             </plugins>
         </pluginManagement>
 
@@ -426,7 +431,7 @@
     <properties>
         <carbon.datasource.version>1.1.10-SNAPSHOT</carbon.datasource.version>
         <carbon.feature.plugin.version>3.1.3</carbon.feature.plugin.version>
-        <commons.io.version>2.4.0.wso2v1</commons.io.version>
+        <commons.io.version>2.7.0.wso2v1</commons.io.version>
         <org.apache.felix.version>1.0.0</org.apache.felix.version>
         <com.zaxxer.hikaricp.version>3.3.1</com.zaxxer.hikaricp.version>
         <java.version>1.8</java.version>


### PR DESCRIPTION
Related Issues: wso2/product-is#12485
## Purpose
> Update common-io version to 2.7.0.wso2v1.
> Findbug maven plugin is required to build the product.